### PR TITLE
Remove truncating from device name printing.

### DIFF
--- a/scripts/pifconfig
+++ b/scripts/pifconfig
@@ -63,7 +63,7 @@ def show_config(device):
     ipaddr = ethtool.get_ipaddr(device)
     netmask = ethtool.get_netmask(device)
     flags = ethtool.get_flags(device)
-    print('%-9.9s' % device)
+    print('%s' % device)
     if not (flags & ethtool.IFF_LOOPBACK):
         print('\tHWaddr %s' % ethtool.get_hwaddr(device))
     print('\tinet addr:%s' % ipaddr)


### PR DESCRIPTION
Because there is a newline between device name and HW address in the new version of ethtool/pifconfig, truncating and left alignment doesn't make sense.

The question is whether we want a newline between device name and HW address because it was done by coincidence (IMHO) during changing the syntax to Python 3 compatible form by @hroncok. Commit: https://github.com/fedora-python/python-ethtool/commit/bedc6e11c74ac47501a063dce15ff5ce2fe4d90f

What do you think? Do we want this slightly different output of pifconfig? Could this change break something?