### PR TITLE
Change README blurb to better match actual ethtool purpose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Python ethtool module
 
 *Python bindings for the ethtool kernel interface*
 
-The Python ``ethtool`` module allows querying and changing of ethernet card settings,
-such as speed, port, autonegotiation, and PCI locations.
+The Python ``ethtool`` module allows querying and partially controlling network
+interfaces, driver, and hardware settings.
 
 **This is the new upstream for python-ethtool maintained by Fedora's
 Python SIG.**


### PR DESCRIPTION
From `ethtool(8)`:

           ethtool - query or control network driver and hardware settings

From `ifconfig(8)`:

           ifconfig - configure a network interface
