### PR TITLE
setup.py: Open text files with utf-8 encoding explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 from setuptools import setup, Extension
 import sys
+from io import open
 
 try:
     import commands
@@ -90,10 +91,10 @@ class PkgConfigExtension(Extension):
         pass
 
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
-with open('CHANGES.rst') as f:
+with open('CHANGES.rst', encoding='utf-8') as f:
     long_description += '\n\n'
     long_description += f.read()
 


### PR DESCRIPTION
With ASCII locale, it blows up otherwise on Python 3.5 and Python 3.6 on non-Fedora systems, as we have Czech characters in both README and CHANGES.

Fixes https://github.com/fedora-python/python-ethtool/issues/46