### PR TITLE
Fix issue when interface has no IPv4 address assigned.

### DIFF
--- a/scripts/pifconfig
+++ b/scripts/pifconfig
@@ -60,16 +60,23 @@ def flags2str(flags):
 
 
 def show_config(device):
-    ipaddr = ethtool.get_ipaddr(device)
-    netmask = ethtool.get_netmask(device)
+    try:
+        ipaddr = ethtool.get_ipaddr(device)
+        netmask = ethtool.get_netmask(device)
+        broadcast = ethtool.get_broadcast(device)
+    except (IOError, OSError):
+        ipaddr, netmask, broadcast = None, None, None
     flags = ethtool.get_flags(device)
     print('%s' % device)
     if not (flags & ethtool.IFF_LOOPBACK):
         print('\tHWaddr %s' % ethtool.get_hwaddr(device))
-    print('\tinet addr:%s' % ipaddr)
-    if not (flags & (ethtool.IFF_LOOPBACK | ethtool.IFF_POINTOPOINT)):
-        print('\tBcast:%s' % ethtool.get_broadcast(device))
-    print('\tMask:%s' % netmask)
+    if ipaddr is not None:
+        print('\tinet addr:%s' % ipaddr)
+    if broadcast is not None and \
+       not (flags & (ethtool.IFF_LOOPBACK | ethtool.IFF_POINTOPOINT)):
+        print('\tBcast:%s' % broadcast)
+    if netmask is not None:
+        print('\tMask:%s' % netmask)
     for info in ethtool.get_interfaces_info(device):
         for addr in info.get_ipv6_addresses():
             print('\tinet6 addr: %s/%s Scope: %s'


### PR DESCRIPTION
`pifconfig` crashes when tries to print info about an interface with no IPv4 address assigned.

For example, I have two interfaces, one without IPv4 address:
```
$ ip addr show dev lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
$ ip addr show dev enp0s31f6
2: enp0s31f6: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN group default qlen 1000
    link/ether 50:7b:9d:e6:53:38 brd ff:ff:ff:ff:ff:ff
```
`pifconfig` crashes when it comes to printing info about the second interface:
```
$ ./pifconfig 
lo
	inet addr:127.0.0.1
	Mask:255.0.0.0
	inet6 addr: ::1/128 Scope: host
	UP LOOPBACK RUNNING

** ERROR ** [Device enp0s31f6]: [Errno 99] Cannot assign requested address
```
After this change, it omits info about IPV4 address/network/broadcast when it cannot get it from OS:
```
$ ./pifconfig 
lo
	inet addr:127.0.0.1
	Mask:255.0.0.0
	inet6 addr: ::1/128 Scope: host
	UP LOOPBACK RUNNING

enp0s31f6
	HWaddr 50:7b:9d:e6:53:38
	UP BROADCAST MULTICAST
```
