### PR TITLE
Fix multiple ipv4 addrs bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,23 @@ cache:
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
 notifications:
   email: false
-install: pip install --upgrade tox tox-travis
+install:
+- pip install --upgrade tox tox-travis
+- sudo ip link add dummy1 type dummy
+- sudo ip link add dummy4 type dummy
+- sudo ip addr add 203.0.113.1 broadcast 203.0.113.255 dev dummy4
+- sudo ip addr add 198.51.100.1 broadcast 198.51.100.255 dev dummy4
+- sudo ip link set dummy1 up
+- sudo ip link set dummy4 up
+# Be ready for IPv6
+# - sudo ip link add dummy46 type dummy
+# - sudo ip addr add 203.0.113.10 broadcast 203.0.113.255 dev dummy46
+# - sudo ip addr add 198.51.100.10 broadcast 198.51.100.255 dev dummy46
+# - sudo ip addr add 2001:db8::10/64 dev dummy46
+# - sudo ip addr add 2001:db9::10/64 dev dummy46
+# - sudo ip link add dummy6 type dummy
+# - sudo ip addr add 2001:db8::1/64 dev dummy6
+# - sudo ip addr add 2001:db9::1/64 dev dummy6
+# - sudo ip link set dummy6 up
+# - sudo ip link set dummy46 up
 script: tox

--- a/scripts/pifconfig
+++ b/scripts/pifconfig
@@ -17,8 +17,15 @@
 from __future__ import unicode_literals, print_function
 
 import ethtool
+import socket
+import struct
 import sys
 from optparse import OptionParser
+
+
+def bits2netmask(bits):
+    mask = (1 << 32) - (1 << 32 >> bits)
+    return socket.inet_ntoa(struct.pack(">L", mask))
 
 
 def flags2str(flags):
@@ -60,24 +67,19 @@ def flags2str(flags):
 
 
 def show_config(device):
-    try:
-        ipaddr = ethtool.get_ipaddr(device)
-        netmask = ethtool.get_netmask(device)
-        broadcast = ethtool.get_broadcast(device)
-    except (IOError, OSError):
-        ipaddr, netmask, broadcast = None, None, None
     flags = ethtool.get_flags(device)
-    print('%s' % device)
-    if not (flags & ethtool.IFF_LOOPBACK):
-        print('\tHWaddr %s' % ethtool.get_hwaddr(device))
-    if ipaddr is not None:
-        print('\tinet addr:%s' % ipaddr)
-    if broadcast is not None and \
-       not (flags & (ethtool.IFF_LOOPBACK | ethtool.IFF_POINTOPOINT)):
-        print('\tBcast:%s' % broadcast)
-    if netmask is not None:
-        print('\tMask:%s' % netmask)
+
     for info in ethtool.get_interfaces_info(device):
+        print(device)
+        if not (flags & ethtool.IFF_LOOPBACK):
+                print('\tHWaddr %s' % ethtool.get_hwaddr(device))
+
+        for addr in info.get_ipv4_addresses():
+            print('\tinet addr:%s' % addr.address, end=" ")
+            if not (flags & (ethtool.IFF_LOOPBACK | ethtool.IFF_POINTOPOINT)):
+                print('Bcast:%s' % addr.broadcast, end=" ")
+            print('Mask:%s' % bits2netmask(addr.netmask))
+
         for addr in info.get_ipv6_addresses():
             print('\tinet6 addr: %s/%s Scope: %s'
                   % (addr.address,

--- a/tests/test_ethtool.py
+++ b/tests/test_ethtool.py
@@ -175,17 +175,20 @@ class EthtoolTests(unittest.TestCase):
             scraped = None
 
         self.assertIsStringOrNone(ei.ipv4_address)
-        if scraped:
-            self.assertEqual(ei.ipv4_address, scraped.inet)
+        if scraped and scraped.inet:
+            addresses = [ip.address for ip in ei.get_ipv4_addresses()]
+            self.assertTrue(scraped.inet in addresses)
 
         self.assertIsStringOrNone(ei.ipv4_broadcast)
-        if scraped and scraped.broadcast:
+        if scraped and scraped.broadcast not in (None, '0.0.0.0'):
             # Broadcast is optional
-            self.assertEqual(ei.ipv4_broadcast, scraped.broadcast)
+            broadcasts = [ip.broadcast for ip in ei.get_ipv4_addresses()]
+            self.assertTrue(scraped.broadcast in broadcasts)
 
         self.assertIsInt(ei.ipv4_netmask)
-        if scraped:
-            self.assertEqual(ei.ipv4_netmask, scraped.get_netmask_bits())
+        if scraped and scraped.netmask:
+            netmasks = [ip.netmask for ip in ei.get_ipv4_addresses()]
+            self.assertTrue(scraped.get_netmask_bits(), netmasks)
 
         self.assertIsStringOrNone(ei.mac_address)
         if scraped and scraped.hwaddr and scraped.hwtitle.lower() != 'unspec':


### PR DESCRIPTION
`pifconfig` is unable to show multiple IPv4 addresses attached to one interface - this is basically the same behavior as `ifconfig` command has but there is an old patch in RHEL which allows it so it might be a good idea to backport it here and provide the same functionality in all versions.

Example output in RHEL 7:
```
dummy0 HWaddr 66:78:8f:23:38:94
          inet addr:10.20.30.40 Bcast:10.20.30.255   Mask:255.255.255.255
          inet addr:10.20.30.45 Bcast:10.20.30.255   Mask:255.255.255.255
          inet addr:10.20.30.50 Bcast:10.20.30.255   Mask:255.255.255.255
	  inet6 addr: fe80::6478:8fff:fe23:3894/64 Scope: link
	  UP BROADCAST RUNNING NOARP
```

Example output with the newest ethtool:
```
dummy0
	HWaddr 6a:83:e2:25:65:69
	inet addr:10.20.30.40
	Bcast:10.20.30.255
	Mask:255.255.255.255
	inet6 addr: fe80::6883:e2ff:fe25:6569/64 Scope: link
	UP BROADCAST RUNNING NOARP
```

Output with merged patch:
```
dummy0
	HWaddr 22:ea:1d:9b:c9:e2
	inet addr:10.20.30.40 Bcast:10.20.30.255 Mask:255.255.255.255
	inet addr:10.20.30.45 Bcast:10.20.30.255 Mask:255.255.255.255
	inet addr:10.20.30.50 Bcast:10.20.30.255 Mask:255.255.255.255
	inet6 addr: fe80::20ea:1dff:fe9b:c9e2/64 Scope: link
	UP BROADCAST RUNNING NOARP
```
I'd say that the last one is the most readable because every IPv4/IPv6 record is on one line.

If you disagree, I'll have to maintain this patch in the new versions of RHEL to keep desired functionality.
